### PR TITLE
Generalize plugin API to multi-root path model (v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1, wasm32-unknown-unknown
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -71,8 +71,11 @@ jobs:
       - name: Clippy (Linter)
         run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
 
-      - name: Build security test plugin
-        run: cargo build --release --target wasm32-wasip1 --manifest-path plugins/security-test/Cargo.toml
+      - name: Build plugins for tests
+        run: |
+          cargo build --release --target wasm32-wasip1 --manifest-path plugins/security-test/Cargo.toml
+          cargo build --release --target wasm32-unknown-unknown --manifest-path plugins/skyrim-se/Cargo.toml
+          cargo build --release --target wasm32-unknown-unknown --manifest-path plugins/witcher3/Cargo.toml
 
       - name: Rust Tests
         run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/plugins/security-test/src/lib.rs
+++ b/plugins/security-test/src/lib.rs
@@ -1,12 +1,45 @@
 use extism_pdk::*;
 use serde::{Deserialize, Serialize};
 
+const GAME_ROOT_ID: &str = "game";
+
 #[derive(Serialize)]
 struct GameMetadata {
+    api_version: u32,
     name: String,
-    mod_directory: String,
-    load_order_file: String,
     executable: String,
+    path_roots: Vec<GamePathRoot>,
+    mod_discovery: ModDiscovery,
+    load_order_writes: Vec<LoadOrderWriteTarget>,
+}
+
+#[derive(Serialize)]
+struct GamePathRoot {
+    id: String,
+    name: String,
+    description: String,
+}
+
+#[derive(Serialize)]
+struct ModDiscovery {
+    root_id: String,
+    relative_path: String,
+    mode: ModDiscoveryMode,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ModDiscoveryMode {
+    DirectoryMods {
+        required_prefix: Option<String>,
+        metadata_file: Option<String>,
+    },
+}
+
+#[derive(Serialize)]
+struct LoadOrderWriteTarget {
+    root_id: String,
+    relative_path: String,
 }
 
 #[derive(Deserialize)]
@@ -17,12 +50,18 @@ struct ModEntry {
 }
 
 #[derive(Deserialize)]
-struct WriteLoadOrderInput {
+struct BuildLoadOrderInput {
     mods: Vec<ModEntry>,
 }
 
 #[derive(Serialize)]
-struct WriteLoadOrderOutput {
+struct BuildLoadOrderOutput {
+    writes: Vec<GameFileWrite>,
+}
+
+#[derive(Serialize)]
+struct GameFileWrite {
+    root_id: String,
     relative_path: String,
     content: String,
 }
@@ -55,37 +94,57 @@ fn probe_result(operation: &str, result: Result<String, String>) -> ProbeResult 
 }
 
 #[plugin_fn]
-pub fn get_game_name() -> FnResult<String> {
-    Ok("Security Test Plugin".to_string())
-}
-
-#[plugin_fn]
 pub fn get_game_metadata() -> FnResult<String> {
     let metadata = GameMetadata {
+        api_version: 2,
         name: "Security Test Plugin".to_string(),
-        mod_directory: "mods".to_string(),
-        load_order_file: "security-loadorder.txt".to_string(),
         executable: "security-test.exe".to_string(),
+        path_roots: vec![GamePathRoot {
+            id: GAME_ROOT_ID.to_string(),
+            name: "Security test game folder".to_string(),
+            description: "Folder used for security probe mod discovery.".to_string(),
+        }],
+        mod_discovery: ModDiscovery {
+            root_id: GAME_ROOT_ID.to_string(),
+            relative_path: "mods".to_string(),
+            mode: ModDiscoveryMode::DirectoryMods {
+                required_prefix: None,
+                metadata_file: None,
+            },
+        },
+        load_order_writes: vec![LoadOrderWriteTarget {
+            root_id: GAME_ROOT_ID.to_string(),
+            relative_path: "security-loadorder.txt".to_string(),
+        }],
     };
     Ok(serde_json::to_string(&metadata)?)
 }
 
 #[plugin_fn]
-pub fn write_load_order(input: String) -> FnResult<String> {
-    let data: WriteLoadOrderInput = serde_json::from_str(&input)?;
-
-    let mut enabled: Vec<&ModEntry> = data.mods.iter().filter(|m| m.enabled).collect();
-    enabled.sort_by_key(|m| m.priority);
-
-    let content = enabled
+pub fn build_load_order(input: String) -> FnResult<String> {
+    let input: BuildLoadOrderInput = serde_json::from_str(&input)?;
+    let mut enabled: Vec<&ModEntry> = input
+        .mods
         .iter()
-        .map(|m| m.id.as_str())
+        .filter(|game_mod| game_mod.enabled)
+        .collect();
+    enabled.sort_by_key(|game_mod| game_mod.priority);
+
+    let mut content = enabled
+        .iter()
+        .map(|game_mod| game_mod.id.as_str())
         .collect::<Vec<_>>()
         .join("\n");
+    if !content.is_empty() {
+        content.push('\n');
+    }
 
-    let output = WriteLoadOrderOutput {
-        relative_path: "security-loadorder.txt".to_string(),
-        content,
+    let output = BuildLoadOrderOutput {
+        writes: vec![GameFileWrite {
+            root_id: GAME_ROOT_ID.to_string(),
+            relative_path: "security-loadorder.txt".to_string(),
+            content,
+        }],
     };
     Ok(serde_json::to_string(&output)?)
 }

--- a/plugins/skyrim-se/src/lib.rs
+++ b/plugins/skyrim-se/src/lib.rs
@@ -1,12 +1,53 @@
 use extism_pdk::*;
 use serde::{Deserialize, Serialize};
 
+const OFFICIAL_MASTERS: &[&str] = &[
+    "Skyrim.esm",
+    "Update.esm",
+    "Dawnguard.esm",
+    "HearthFires.esm",
+    "Dragonborn.esm",
+];
+const GAME_ROOT_ID: &str = "game";
+const LOCAL_APP_DATA_ROOT_ID: &str = "local_app_data";
+
 #[derive(Serialize)]
 struct GameMetadata {
+    api_version: u32,
     name: String,
-    mod_directory: String,
-    load_order_file: String,
     executable: String,
+    path_roots: Vec<GamePathRoot>,
+    mod_discovery: ModDiscovery,
+    load_order_writes: Vec<LoadOrderWriteTarget>,
+}
+
+#[derive(Serialize)]
+struct GamePathRoot {
+    id: String,
+    name: String,
+    description: String,
+}
+
+#[derive(Serialize)]
+struct ModDiscovery {
+    root_id: String,
+    relative_path: String,
+    mode: ModDiscoveryMode,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ModDiscoveryMode {
+    PluginFiles {
+        extensions: Vec<String>,
+        excluded_files: Vec<String>,
+    },
+}
+
+#[derive(Serialize)]
+struct LoadOrderWriteTarget {
+    root_id: String,
+    relative_path: String,
 }
 
 #[derive(Deserialize)]
@@ -17,58 +58,165 @@ struct ModEntry {
 }
 
 #[derive(Deserialize)]
-struct WriteLoadOrderInput {
+struct BuildLoadOrderInput {
     mods: Vec<ModEntry>,
 }
 
 #[derive(Serialize)]
-struct WriteLoadOrderOutput {
+struct BuildLoadOrderOutput {
+    writes: Vec<GameFileWrite>,
+}
+
+#[derive(Serialize)]
+struct GameFileWrite {
+    root_id: String,
     relative_path: String,
     content: String,
 }
 
 #[plugin_fn]
-pub fn get_game_name() -> FnResult<String> {
-    Ok("Skyrim Special Edition".to_string())
-}
-
-#[plugin_fn]
 pub fn get_game_metadata() -> FnResult<String> {
     let metadata = GameMetadata {
+        api_version: 2,
         name: "Skyrim Special Edition".to_string(),
-        mod_directory: "mods".to_string(),
-        load_order_file: "loadorder.txt".to_string(),
-        executable: "game.exe".to_string(),
+        executable: "SkyrimSE.exe".to_string(),
+        path_roots: vec![
+            GamePathRoot {
+                id: GAME_ROOT_ID.to_string(),
+                name: "Skyrim install folder".to_string(),
+                description: "Folder containing SkyrimSE.exe and the Data directory.".to_string(),
+            },
+            GamePathRoot {
+                id: LOCAL_APP_DATA_ROOT_ID.to_string(),
+                name: "Skyrim local app data folder".to_string(),
+                description: "Folder containing plugins.txt and loadorder.txt.".to_string(),
+            },
+        ],
+        mod_discovery: ModDiscovery {
+            root_id: GAME_ROOT_ID.to_string(),
+            relative_path: "Data".to_string(),
+            mode: ModDiscoveryMode::PluginFiles {
+                extensions: vec!["esm".to_string(), "esp".to_string(), "esl".to_string()],
+                excluded_files: vec![
+                    "Skyrim.esm".to_string(),
+                    "Update.esm".to_string(),
+                    "Dawnguard.esm".to_string(),
+                    "HearthFires.esm".to_string(),
+                    "Dragonborn.esm".to_string(),
+                ],
+            },
+        },
+        load_order_writes: vec![
+            LoadOrderWriteTarget {
+                root_id: LOCAL_APP_DATA_ROOT_ID.to_string(),
+                relative_path: "plugins.txt".to_string(),
+            },
+            LoadOrderWriteTarget {
+                root_id: LOCAL_APP_DATA_ROOT_ID.to_string(),
+                relative_path: "loadorder.txt".to_string(),
+            },
+        ],
     };
     Ok(serde_json::to_string(&metadata)?)
 }
 
 #[plugin_fn]
-pub fn write_load_order(input: String) -> FnResult<String> {
-    let data: WriteLoadOrderInput = serde_json::from_str(&input)?;
-
-    let mut enabled: Vec<&ModEntry> = data.mods.iter().filter(|m| m.enabled).collect();
-    enabled.sort_by_key(|m| m.priority);
-
-    let content = enabled
-        .iter()
-        .map(|m| m.id.as_str())
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let output = WriteLoadOrderOutput {
-        relative_path: "loadorder.txt".to_string(),
-        content,
+pub fn build_load_order(input: String) -> FnResult<String> {
+    let input: BuildLoadOrderInput = serde_json::from_str(&input)?;
+    let output = BuildLoadOrderOutput {
+        writes: vec![
+            GameFileWrite {
+                root_id: LOCAL_APP_DATA_ROOT_ID.to_string(),
+                relative_path: "plugins.txt".to_string(),
+                content: format_plugins_txt(&input.mods),
+            },
+            GameFileWrite {
+                root_id: LOCAL_APP_DATA_ROOT_ID.to_string(),
+                relative_path: "loadorder.txt".to_string(),
+                content: format_loadorder_txt(&input.mods),
+            },
+        ],
     };
     Ok(serde_json::to_string(&output)?)
 }
 
-#[plugin_fn]
-pub fn read_load_order(content: String) -> FnResult<String> {
-    let order: Vec<String> = content
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(|l| l.trim().to_string())
-        .collect();
-    Ok(serde_json::to_string(&order)?)
+fn sorted_mods(mods: &[ModEntry]) -> Vec<&ModEntry> {
+    let mut sorted: Vec<&ModEntry> = mods.iter().collect();
+    sorted.sort_by_key(|game_mod| game_mod.priority);
+    sorted
+}
+
+fn format_plugins_txt(mods: &[ModEntry]) -> String {
+    let mut lines = OFFICIAL_MASTERS
+        .iter()
+        .map(|master| format!("*{master}"))
+        .collect::<Vec<_>>();
+
+    for game_mod in sorted_mods(mods) {
+        if game_mod.enabled {
+            lines.push(format!("*{}", game_mod.id));
+        } else {
+            lines.push(game_mod.id.clone());
+        }
+    }
+
+    join_lines_with_trailing_newline(lines)
+}
+
+fn format_loadorder_txt(mods: &[ModEntry]) -> String {
+    let mut lines = OFFICIAL_MASTERS
+        .iter()
+        .map(|master| (*master).to_string())
+        .collect::<Vec<_>>();
+
+    for game_mod in sorted_mods(mods) {
+        lines.push(game_mod.id.clone());
+    }
+
+    join_lines_with_trailing_newline(lines)
+}
+
+fn join_lines_with_trailing_newline(lines: Vec<String>) -> String {
+    let mut content = lines.join("\n");
+    content.push('\n');
+    content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mod_entry(id: &str, enabled: bool, priority: u32) -> ModEntry {
+        ModEntry {
+            id: id.to_string(),
+            enabled,
+            priority,
+        }
+    }
+
+    #[test]
+    fn plugins_txt_prepends_masters_and_marks_enabled_mods() {
+        let mods = vec![
+            mod_entry("DisabledPatch.esp", false, 20),
+            mod_entry("SkyUI_SE.esp", true, 10),
+        ];
+
+        assert_eq!(
+            format_plugins_txt(&mods),
+            "*Skyrim.esm\n*Update.esm\n*Dawnguard.esm\n*HearthFires.esm\n*Dragonborn.esm\n*SkyUI_SE.esp\nDisabledPatch.esp\n"
+        );
+    }
+
+    #[test]
+    fn loadorder_txt_uses_same_order_without_enabled_prefixes() {
+        let mods = vec![
+            mod_entry("DisabledPatch.esp", false, 20),
+            mod_entry("SkyUI_SE.esp", true, 10),
+        ];
+
+        assert_eq!(
+            format_loadorder_txt(&mods),
+            "Skyrim.esm\nUpdate.esm\nDawnguard.esm\nHearthFires.esm\nDragonborn.esm\nSkyUI_SE.esp\nDisabledPatch.esp\n"
+        );
+    }
 }

--- a/plugins/witcher3/src/lib.rs
+++ b/plugins/witcher3/src/lib.rs
@@ -1,13 +1,46 @@
 use extism_pdk::*;
 use serde::{Deserialize, Serialize};
 
+const GAME_ROOT_ID: &str = "game";
+const DOCUMENTS_ROOT_ID: &str = "documents";
+
 #[derive(Serialize)]
 struct GameMetadata {
+    api_version: u32,
     name: String,
-    mod_directory: String,
-    mod_extension: String,
-    load_order_file: String,
     executable: String,
+    path_roots: Vec<GamePathRoot>,
+    mod_discovery: ModDiscovery,
+    load_order_writes: Vec<LoadOrderWriteTarget>,
+}
+
+#[derive(Serialize)]
+struct GamePathRoot {
+    id: String,
+    name: String,
+    description: String,
+}
+
+#[derive(Serialize)]
+struct ModDiscovery {
+    root_id: String,
+    relative_path: String,
+    mode: ModDiscoveryMode,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ModDiscoveryMode {
+    DirectoryMods {
+        required_prefix: Option<String>,
+        metadata_file: Option<String>,
+    },
+}
+
+#[derive(Serialize)]
+struct LoadOrderWriteTarget {
+    root_id: String,
+    relative_path: String,
 }
 
 #[derive(Deserialize)]
@@ -18,59 +51,117 @@ struct ModEntry {
 }
 
 #[derive(Deserialize)]
-struct WriteLoadOrderInput {
+struct BuildLoadOrderInput {
     mods: Vec<ModEntry>,
 }
 
 #[derive(Serialize)]
-struct WriteLoadOrderOutput {
+struct BuildLoadOrderOutput {
+    writes: Vec<GameFileWrite>,
+}
+
+#[derive(Serialize)]
+struct GameFileWrite {
+    root_id: String,
     relative_path: String,
     content: String,
 }
 
 #[plugin_fn]
-pub fn get_game_name() -> FnResult<String> {
-    Ok("The Witcher 3: Wild Hunt".to_string())
-}
-
-#[plugin_fn]
 pub fn get_game_metadata() -> FnResult<String> {
     let metadata = GameMetadata {
+        api_version: 2,
         name: "The Witcher 3: Wild Hunt".to_string(),
-        mod_directory: "Data".to_string(),
-        mod_extension: ".data".to_string(),
-        load_order_file: "order.txt".to_string(),
-        executable: "witcher3.exe".to_string(),
+        executable: "bin/x64/witcher3.exe".to_string(),
+        path_roots: vec![
+            GamePathRoot {
+                id: GAME_ROOT_ID.to_string(),
+                name: "Witcher 3 install folder".to_string(),
+                description: "Folder containing bin, content, dlc, and mods.".to_string(),
+            },
+            GamePathRoot {
+                id: DOCUMENTS_ROOT_ID.to_string(),
+                name: "Witcher 3 documents folder".to_string(),
+                description: "Folder containing mods.settings.".to_string(),
+            },
+        ],
+        mod_discovery: ModDiscovery {
+            root_id: GAME_ROOT_ID.to_string(),
+            relative_path: "mods".to_string(),
+            mode: ModDiscoveryMode::DirectoryMods {
+                required_prefix: Some("mod".to_string()),
+                metadata_file: None,
+            },
+        },
+        load_order_writes: vec![LoadOrderWriteTarget {
+            root_id: DOCUMENTS_ROOT_ID.to_string(),
+            relative_path: "mods.settings".to_string(),
+        }],
     };
     Ok(serde_json::to_string(&metadata)?)
 }
 
 #[plugin_fn]
-pub fn write_load_order(input: String) -> FnResult<String> {
-    let data: WriteLoadOrderInput = serde_json::from_str(&input)?;
-
-    let mut enabled: Vec<&ModEntry> = data.mods.iter().filter(|m| m.enabled).collect();
-    enabled.sort_by_key(|m| m.priority);
-
-    let content = enabled
-        .iter()
-        .map(|m| m.id.as_str())
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let output = WriteLoadOrderOutput {
-        relative_path: "order.txt".to_string(),
-        content,
+pub fn build_load_order(input: String) -> FnResult<String> {
+    let input: BuildLoadOrderInput = serde_json::from_str(&input)?;
+    let output = BuildLoadOrderOutput {
+        writes: vec![GameFileWrite {
+            root_id: DOCUMENTS_ROOT_ID.to_string(),
+            relative_path: "mods.settings".to_string(),
+            content: format_mods_settings(&input.mods),
+        }],
     };
     Ok(serde_json::to_string(&output)?)
 }
 
-#[plugin_fn]
-pub fn read_load_order(content: String) -> FnResult<String> {
-    let order: Vec<String> = content
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(|l| l.trim().to_string())
-        .collect();
-    Ok(serde_json::to_string(&order)?)
+fn sorted_mods(mods: &[ModEntry]) -> Vec<&ModEntry> {
+    let mut sorted: Vec<&ModEntry> = mods.iter().collect();
+    sorted.sort_by_key(|game_mod| game_mod.priority);
+    sorted
+}
+
+fn format_mods_settings(mods: &[ModEntry]) -> String {
+    let sorted = sorted_mods(mods);
+    let mut content = String::new();
+
+    for (index, game_mod) in sorted.iter().enumerate() {
+        if index > 0 {
+            content.push('\n');
+        }
+
+        let enabled = if game_mod.enabled { 1 } else { 0 };
+        let priority = index + 1;
+        content.push_str(&format!(
+            "[{}]\nEnabled={enabled}\nPriority={priority}\n",
+            game_mod.id
+        ));
+    }
+
+    content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mod_entry(id: &str, enabled: bool, priority: u32) -> ModEntry {
+        ModEntry {
+            id: id.to_string(),
+            enabled,
+            priority,
+        }
+    }
+
+    #[test]
+    fn mods_settings_uses_directory_ids_and_one_based_sorted_priorities() {
+        let mods = vec![
+            mod_entry("modBetterWeather", false, 20),
+            mod_entry("modArmorEnhanced", true, 10),
+        ];
+
+        assert_eq!(
+            format_mods_settings(&mods),
+            "[modArmorEnhanced]\nEnabled=1\nPriority=1\n\n[modBetterWeather]\nEnabled=0\nPriority=2\n"
+        );
+    }
 }

--- a/src-tauri/src/commands/mods.rs
+++ b/src-tauri/src/commands/mods.rs
@@ -1,6 +1,8 @@
-use crate::models::ModInfo;
+use crate::models::{BuildLoadOrderInput, BuildLoadOrderOutput, GameMetadata, ModEntry, ModInfo};
+use crate::services::join_validated_plugin_path;
 use crate::state::AppState;
-use std::path::{Component, Path};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 #[tauri::command]
 #[specta::specta]
@@ -36,129 +38,215 @@ pub fn reorder_mods(state: tauri::State<'_, AppState>, mod_ids: Vec<String>) -> 
 }
 
 fn sync_load_order_to_game(state: &AppState) -> Result<(), String> {
-    let (plugin_id, game_path) = {
+    let plugin_id = {
         let config = state.config.lock().map_err(|e| e.to_string())?;
-        let pid = match config.active_plugin.as_deref() {
+        match config.active_plugin.as_deref() {
             Some(id) => id.to_string(),
             None => return Ok(()),
-        };
-        let gp = config
-            .game_paths
-            .get(&pid)
-            .ok_or_else(|| format!("No game path for '{}'", pid))?
-            .clone();
-        (pid, gp)
+        }
     };
 
     let mods = {
         let mgr = state.mod_manager.lock().map_err(|e| e.to_string())?;
         mgr.list_mods()
+            .into_iter()
+            .map(|game_mod| ModEntry {
+                id: game_mod.id,
+                enabled: game_mod.enabled,
+                priority: game_mod.priority,
+            })
+            .collect()
     };
+    let input = BuildLoadOrderInput { mods };
 
-    let input = serde_json::json!({ "mods": mods }).to_string();
-
-    let result = {
+    let (metadata, output) = {
         let plugin_mgr = state.plugin_manager.lock().map_err(|e| e.to_string())?;
-        plugin_mgr
-            .call_plugin_fn(&plugin_id, "write_load_order", &input)
-            .map_err(|e| e.to_string())?
+        let metadata = plugin_mgr
+            .game_metadata(&plugin_id)
+            .map_err(|e| e.to_string())?;
+        let output = plugin_mgr
+            .build_load_order(&plugin_id, &input)
+            .map_err(|e| e.to_string())?;
+        (metadata, output)
     };
 
-    let output: serde_json::Value = serde_json::from_str(&result).map_err(|e| e.to_string())?;
-    let relative_path = output["relative_path"]
-        .as_str()
-        .ok_or("Plugin returned no relative_path")?;
-    let content = output["content"]
-        .as_str()
-        .ok_or("Plugin returned no content")?;
-
-    validate_plugin_relative_path(relative_path)?;
-
-    let file_path = std::path::Path::new(&game_path).join(relative_path);
-    std::fs::write(&file_path, content).map_err(|e| e.to_string())?;
+    let path_roots = {
+        let config = state.config.lock().map_err(|e| e.to_string())?;
+        config.configured_path_roots(&plugin_id, &metadata)?
+    };
+    write_declared_load_order_files(&plugin_id, &path_roots, &metadata, output)?;
 
     Ok(())
 }
 
-fn validate_plugin_relative_path(relative_path: &str) -> Result<(), String> {
-    if relative_path.trim().is_empty() {
-        return Err("Plugin returned an empty relative_path".to_string());
-    }
+fn write_declared_load_order_files(
+    plugin_id: &str,
+    path_roots: &HashMap<String, String>,
+    metadata: &GameMetadata,
+    output: BuildLoadOrderOutput,
+) -> Result<(), String> {
+    let declared_paths = declared_load_order_paths(metadata);
+    for write in output.writes {
+        ensure_declared_load_order_path(
+            plugin_id,
+            &declared_paths,
+            &write.root_id,
+            &write.relative_path,
+        )?;
+        let root_path = path_roots.get(&write.root_id).ok_or_else(|| {
+            format!(
+                "No path configured for root '{}' in plugin '{}'",
+                write.root_id, plugin_id
+            )
+        })?;
 
-    if relative_path.contains('\\') || relative_path.contains(':') {
-        return Err(format!(
-            "Plugin returned unsafe relative_path: {relative_path}"
-        ));
-    }
-
-    let path = Path::new(relative_path);
-    if path.is_absolute() {
-        return Err(format!(
-            "Plugin returned absolute relative_path: {relative_path}"
-        ));
-    }
-
-    let mut has_file_component = false;
-    for component in path.components() {
-        match component {
-            Component::Normal(_) => has_file_component = true,
-            Component::CurDir
-            | Component::ParentDir
-            | Component::RootDir
-            | Component::Prefix(_) => {
-                return Err(format!(
-                    "Plugin returned unsafe relative_path: {relative_path}"
-                ));
-            }
+        let file_path = join_validated_plugin_path(Path::new(root_path), &write.relative_path)?;
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
-    }
-
-    if !has_file_component {
-        return Err("Plugin returned an empty relative_path".to_string());
+        std::fs::write(&file_path, write.content).map_err(|e| e.to_string())?;
     }
 
     Ok(())
+}
+
+fn declared_load_order_paths(metadata: &GameMetadata) -> HashSet<(&str, &str)> {
+    metadata
+        .load_order_writes
+        .iter()
+        .map(|target| (target.root_id.as_str(), target.relative_path.as_str()))
+        .collect()
+}
+
+fn ensure_declared_load_order_path(
+    plugin_id: &str,
+    declared_paths: &HashSet<(&str, &str)>,
+    root_id: &str,
+    relative_path: &str,
+) -> Result<(), String> {
+    if declared_paths.contains(&(root_id, relative_path)) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Plugin '{plugin_id}' returned undeclared load-order path '{root_id}:{relative_path}'"
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::validate_plugin_relative_path;
+    use super::*;
+    use crate::models::{
+        GameFileWrite, GamePathRoot, LoadOrderWriteTarget, ModDiscovery, ModDiscoveryMode,
+    };
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    #[test]
-    fn plugin_relative_path_allows_normal_relative_paths() {
-        assert!(validate_plugin_relative_path("loadorder.txt").is_ok());
-        assert!(validate_plugin_relative_path("profiles/loadorder.txt").is_ok());
+    static NEXT_TEST_DIR_ID: AtomicUsize = AtomicUsize::new(0);
+
+    struct TestDir {
+        path: PathBuf,
     }
 
-    #[test]
-    fn plugin_relative_path_rejects_traversal_and_absolute_paths() {
-        for path in [
-            "",
-            ".",
-            "./loadorder.txt",
-            "../outside.txt",
-            "profiles/../../outside.txt",
-            "/tmp/outside.txt",
-        ] {
-            assert!(
-                validate_plugin_relative_path(path).is_err(),
-                "path should be rejected: {path}"
-            );
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before UNIX_EPOCH")
+                .as_nanos();
+            let id = NEXT_TEST_DIR_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir()
+                .join(format!("umm-{name}-{}-{nanos}-{id}", std::process::id()));
+            fs::create_dir_all(&path).expect("create temp test directory");
+            Self { path }
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn metadata_with_write_targets(targets: &[(&str, &str)]) -> GameMetadata {
+        GameMetadata {
+            api_version: 2,
+            name: "Example".to_string(),
+            executable: "game.exe".to_string(),
+            path_roots: vec![
+                GamePathRoot {
+                    id: "game".to_string(),
+                    name: "Game folder".to_string(),
+                    description: "Game install folder".to_string(),
+                },
+                GamePathRoot {
+                    id: "local_app_data".to_string(),
+                    name: "Local app data".to_string(),
+                    description: "Local app data folder".to_string(),
+                },
+            ],
+            mod_discovery: ModDiscovery {
+                root_id: "game".to_string(),
+                relative_path: "mods".to_string(),
+                mode: ModDiscoveryMode::DirectoryMods {
+                    required_prefix: None,
+                    metadata_file: None,
+                },
+            },
+            load_order_writes: targets
+                .iter()
+                .map(|(root_id, relative_path)| LoadOrderWriteTarget {
+                    root_id: (*root_id).to_string(),
+                    relative_path: (*relative_path).to_string(),
+                })
+                .collect(),
         }
     }
 
     #[test]
-    fn plugin_relative_path_rejects_windows_prefixes_and_separators() {
-        for path in [
-            "C:/Users/player/outside.txt",
-            "C:\\Users\\player\\outside.txt",
-            "\\\\server\\share\\outside.txt",
-            "profiles\\loadorder.txt",
-        ] {
-            assert!(
-                validate_plugin_relative_path(path).is_err(),
-                "path should be rejected: {path}"
-            );
-        }
+    fn load_order_write_path_must_be_declared_by_plugin_metadata() {
+        let metadata = metadata_with_write_targets(&[("local_app_data", "declared.txt")]);
+        let declared_paths = declared_load_order_paths(&metadata);
+
+        assert!(ensure_declared_load_order_path(
+            "example",
+            &declared_paths,
+            "local_app_data",
+            "declared.txt"
+        )
+        .is_ok());
+        assert_eq!(
+            ensure_declared_load_order_path("example", &declared_paths, "game", "other.txt")
+                .expect_err("undeclared write target should be rejected"),
+            "Plugin 'example' returned undeclared load-order path 'game:other.txt'"
+        );
+    }
+
+    #[test]
+    fn declared_load_order_writes_create_nested_files() {
+        let temp_dir = TestDir::new("declared-load-order-write");
+        let relative_path = "plugins.txt";
+        let metadata = metadata_with_write_targets(&[("local_app_data", relative_path)]);
+        let output = BuildLoadOrderOutput {
+            writes: vec![GameFileWrite {
+                root_id: "local_app_data".to_string(),
+                relative_path: relative_path.to_string(),
+                content: "*Skyrim.esm\n".to_string(),
+            }],
+        };
+
+        let path_roots = HashMap::from([(
+            "local_app_data".to_string(),
+            temp_dir.path.to_string_lossy().to_string(),
+        )]);
+        write_declared_load_order_files("skyrim-se", &path_roots, &metadata, output)
+            .expect("write declared load-order file");
+
+        let content =
+            fs::read_to_string(temp_dir.path.join(relative_path)).expect("read load-order file");
+        assert_eq!(content, "*Skyrim.esm\n");
     }
 }

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -28,32 +28,22 @@ pub fn select_plugin(
             .map_err(|e| e.to_string())?;
     }
 
-    let mod_directory = {
+    let metadata = {
         let plugin_mgr = state.plugin_manager.lock().map_err(|e| e.to_string())?;
-        let metadata_json = plugin_mgr
-            .call_plugin_fn(&plugin_id, "get_game_metadata", "")
-            .map_err(|e| e.to_string())?;
-        let metadata: serde_json::Value =
-            serde_json::from_str(&metadata_json).map_err(|e| e.to_string())?;
-        metadata["mod_directory"]
-            .as_str()
-            .unwrap_or("mods")
-            .to_string()
+        plugin_mgr
+            .game_metadata(&plugin_id)
+            .map_err(|e| e.to_string())?
     };
 
-    let game_path = {
+    let path_roots = {
         let config = state.config.lock().map_err(|e| e.to_string())?;
-        config
-            .game_paths
-            .get(&plugin_id)
-            .ok_or_else(|| format!("No game path configured for '{}'", plugin_id))?
-            .clone()
+        config.configured_path_roots(&plugin_id, &metadata)?
     };
 
     let mods = {
         let mut mod_mgr = state.mod_manager.lock().map_err(|e| e.to_string())?;
         mod_mgr
-            .load_mods_for_plugin(&plugin_id, &game_path, &mod_directory)
+            .load_mods_for_plugin(&plugin_id, &path_roots, &metadata.mod_discovery)
             .map_err(|e| e.to_string())?;
         mod_mgr.list_mods()
     };

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,25 +1,41 @@
+use crate::models::{GamePathRoot, PluginPathConfig};
 use crate::state::AppState;
-use std::collections::HashMap;
 
 #[tauri::command]
 #[specta::specta]
-pub fn get_game_paths(
-    state: tauri::State<'_, AppState>,
-) -> Result<HashMap<String, String>, String> {
+pub fn get_plugin_paths(state: tauri::State<'_, AppState>) -> Result<PluginPathConfig, String> {
     let config = state.config.lock().map_err(|e| e.to_string())?;
-    Ok(config.game_paths.clone())
+    Ok(config.plugin_paths.clone())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub fn set_game_path(
+pub fn set_plugin_path(
     state: tauri::State<'_, AppState>,
     plugin_id: String,
+    root_id: String,
     path: String,
 ) -> Result<(), String> {
     let mut config = state.config.lock().map_err(|e| e.to_string())?;
-    config.game_paths.insert(plugin_id, path);
+    config
+        .plugin_paths
+        .entry(plugin_id)
+        .or_default()
+        .insert(root_id, path);
     let content = serde_json::to_string_pretty(&*config).map_err(|e| e.to_string())?;
     std::fs::write(state.data_dir.join("config.json"), content).map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_plugin_path_roots(
+    state: tauri::State<'_, AppState>,
+    plugin_id: String,
+) -> Result<Vec<GamePathRoot>, String> {
+    let plugin_mgr = state.plugin_manager.lock().map_err(|e| e.to_string())?;
+    let metadata = plugin_mgr
+        .game_metadata(&plugin_id)
+        .map_err(|e| e.to_string())?;
+    Ok(metadata.path_roots)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod models;
 mod services;
 mod state;
 
-use models::AppConfig;
+use models::{AppConfig, GAME_INSTALL_PATH_ROOT_ID};
 use services::{ModManager, PluginManager, ThemeManager};
 use state::AppState;
 use std::sync::Mutex;
@@ -19,8 +19,9 @@ pub fn run() {
             commands::plugins::list_plugins,
             commands::plugins::get_active_plugin,
             commands::plugins::select_plugin,
-            commands::settings::get_game_paths,
-            commands::settings::set_game_path,
+            commands::settings::get_plugin_path_roots,
+            commands::settings::get_plugin_paths,
+            commands::settings::set_plugin_path,
             commands::themes::list_themes,
             commands::themes::get_theme_css,
             commands::themes::get_active_theme,
@@ -67,14 +68,14 @@ pub fn run() {
 
             let mut mod_manager = ModManager::new(&data_dir);
             if let Some(plugin_id) = &config.active_plugin {
-                if let Some(game_path) = config.game_paths.get(plugin_id) {
-                    let mod_dir = plugin_manager
-                        .call_plugin_fn(plugin_id, "get_game_metadata", "")
-                        .ok()
-                        .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())
-                        .and_then(|v| v["mod_directory"].as_str().map(|s| s.to_string()))
-                        .unwrap_or_else(|| "mods".to_string());
-                    let _ = mod_manager.load_mods_for_plugin(plugin_id, game_path, &mod_dir);
+                if let Ok(metadata) = plugin_manager.game_metadata(plugin_id) {
+                    if let Ok(path_roots) = config.configured_path_roots(plugin_id, &metadata) {
+                        let _ = mod_manager.load_mods_for_plugin(
+                            plugin_id,
+                            &path_roots,
+                            &metadata.mod_discovery,
+                        );
+                    }
                 }
             }
 
@@ -99,17 +100,43 @@ fn setup_dev_environment(data_dir: &std::path::Path, config: &mut AppConfig) {
         .unwrap()
         .to_path_buf();
 
-    for (id, dir_name) in [
-        ("skyrim-se", "skyrim-se"),
-        ("witcher3", "witcher3"),
-        ("security-test", "security-test"),
+    for (plugin_id, roots) in [
+        (
+            "skyrim-se",
+            &[
+                (GAME_INSTALL_PATH_ROOT_ID, "skyrim-se"),
+                ("local_app_data", "skyrim-se-local-app-data"),
+            ][..],
+        ),
+        (
+            "witcher3",
+            &[
+                (GAME_INSTALL_PATH_ROOT_ID, "witcher3"),
+                ("documents", "witcher3-documents"),
+            ][..],
+        ),
+        (
+            "security-test",
+            &[(GAME_INSTALL_PATH_ROOT_ID, "security-test")][..],
+        ),
     ] {
-        if !config.game_paths.contains_key(id) {
-            let fake_path = project_root.join(format!(".ignored/fake-games/{}", dir_name));
+        for (root_id, dir_name) in roots {
+            let has_path = config
+                .plugin_paths
+                .get(plugin_id)
+                .and_then(|paths| paths.get(*root_id))
+                .is_some();
+            if has_path {
+                continue;
+            }
+
+            let fake_path = project_root.join(format!(".ignored/fake-games/{dir_name}"));
             if fake_path.exists() {
                 config
-                    .game_paths
-                    .insert(id.to_string(), fake_path.to_string_lossy().to_string());
+                    .plugin_paths
+                    .entry(plugin_id.to_string())
+                    .or_default()
+                    .insert(root_id.to_string(), fake_path.to_string_lossy().to_string());
             }
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod models;
 mod services;
 mod state;
 
-use models::{AppConfig, GAME_INSTALL_PATH_ROOT_ID};
+use models::AppConfig;
 use services::{ModManager, PluginManager, ThemeManager};
 use state::AppState;
 use std::sync::Mutex;
@@ -48,6 +48,7 @@ pub fn run() {
             std::fs::create_dir_all(data_dir.join("profiles"))?;
 
             let config_path = data_dir.join("config.json");
+            #[cfg_attr(not(debug_assertions), allow(unused_mut))]
             let mut config: AppConfig = if config_path.exists() {
                 let content = std::fs::read_to_string(&config_path)?;
                 serde_json::from_str(&content).unwrap_or_default()
@@ -95,6 +96,8 @@ pub fn run() {
 
 #[cfg(debug_assertions)]
 fn setup_dev_environment(data_dir: &std::path::Path, config: &mut AppConfig) {
+    use models::GAME_INSTALL_PATH_ROOT_ID;
+
     let project_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()

--- a/src-tauri/src/models/config.rs
+++ b/src-tauri/src/models/config.rs
@@ -1,15 +1,157 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, specta::Type)]
+use super::GAME_INSTALL_PATH_ROOT_ID;
+
+pub type PluginPathConfig = HashMap<String, HashMap<String, String>>;
+
+#[derive(Debug, Clone, Default, Serialize, specta::Type)]
 pub struct AppConfig {
     pub active_plugin: Option<String>,
     pub active_theme: String,
-    pub game_paths: HashMap<String, String>,
+    pub plugin_paths: PluginPathConfig,
+}
+
+#[derive(Default, Deserialize)]
+struct AppConfigFile {
+    #[serde(default)]
+    active_plugin: Option<String>,
+    #[serde(default)]
+    active_theme: String,
+    #[serde(default)]
+    plugin_paths: PluginPathConfig,
+    #[serde(default)]
+    game_paths: HashMap<String, String>,
+}
+
+impl<'de> Deserialize<'de> for AppConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut file = AppConfigFile::deserialize(deserializer)?;
+        for (plugin_id, path) in file.game_paths {
+            file.plugin_paths
+                .entry(plugin_id)
+                .or_default()
+                .entry(GAME_INSTALL_PATH_ROOT_ID.to_string())
+                .or_insert(path);
+        }
+
+        Ok(Self {
+            active_plugin: file.active_plugin,
+            active_theme: file.active_theme,
+            plugin_paths: file.plugin_paths,
+        })
+    }
+}
+
+impl AppConfig {
+    pub fn configured_path_roots(
+        &self,
+        plugin_id: &str,
+        metadata: &super::GameMetadata,
+    ) -> Result<HashMap<String, String>, String> {
+        let configured_paths = self
+            .plugin_paths
+            .get(plugin_id)
+            .ok_or_else(|| format!("No paths configured for '{plugin_id}'"))?;
+
+        let mut roots = HashMap::new();
+        for root in &metadata.path_roots {
+            let path = configured_paths
+                .get(&root.id)
+                .filter(|path| !path.trim().is_empty())
+                .ok_or_else(|| {
+                    format!(
+                        "No path configured for '{}' ({}) in plugin '{}'",
+                        root.name, root.id, plugin_id
+                    )
+                })?;
+            roots.insert(root.id.clone(), path.clone());
+        }
+
+        Ok(roots)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct ThemeInfo {
     pub name: String,
     pub is_active: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{
+        GameMetadata, GamePathRoot, LoadOrderWriteTarget, ModDiscovery, ModDiscoveryMode,
+    };
+
+    fn metadata_with_roots() -> GameMetadata {
+        GameMetadata {
+            api_version: 2,
+            name: "Example".to_string(),
+            executable: "game.exe".to_string(),
+            path_roots: vec![
+                GamePathRoot {
+                    id: "game".to_string(),
+                    name: "Game folder".to_string(),
+                    description: "Game install folder".to_string(),
+                },
+                GamePathRoot {
+                    id: "local_app_data".to_string(),
+                    name: "Local app data".to_string(),
+                    description: "Local app data folder".to_string(),
+                },
+            ],
+            mod_discovery: ModDiscovery {
+                root_id: "game".to_string(),
+                relative_path: "Data".to_string(),
+                mode: ModDiscoveryMode::DirectoryMods {
+                    required_prefix: None,
+                    metadata_file: None,
+                },
+            },
+            load_order_writes: vec![LoadOrderWriteTarget {
+                root_id: "local_app_data".to_string(),
+                relative_path: "plugins.txt".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn old_game_paths_migrate_to_game_root_plugin_paths() {
+        let config: AppConfig = serde_json::from_str(
+            r#"{"active_plugin":"skyrim-se","active_theme":"","game_paths":{"skyrim-se":"/games/skyrim"}}"#,
+        )
+        .expect("deserialize old config");
+
+        assert_eq!(
+            config.plugin_paths["skyrim-se"][GAME_INSTALL_PATH_ROOT_ID],
+            "/games/skyrim"
+        );
+    }
+
+    #[test]
+    fn configured_path_roots_requires_every_declared_root() {
+        let metadata = metadata_with_roots();
+        let config = AppConfig {
+            active_plugin: None,
+            active_theme: String::new(),
+            plugin_paths: HashMap::from([(
+                "skyrim-se".to_string(),
+                HashMap::from([("game".to_string(), "/games/skyrim".to_string())]),
+            )]),
+        };
+
+        let message = config
+            .configured_path_roots("skyrim-se", &metadata)
+            .expect_err("missing local app data path should be rejected");
+
+        assert_eq!(
+            message,
+            "No path configured for 'Local app data' (local_app_data) in plugin 'skyrim-se'"
+        );
+    }
 }

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,7 +1,9 @@
 pub mod config;
 pub mod game_mod;
 pub mod plugin;
+pub mod plugin_api;
 
 pub use config::*;
 pub use game_mod::*;
 pub use plugin::*;
+pub use plugin_api::*;

--- a/src-tauri/src/models/plugin_api.rs
+++ b/src-tauri/src/models/plugin_api.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+use super::ModEntry;
+
+pub const SUPPORTED_PLUGIN_API_VERSION: u32 = 2;
+pub const GAME_INSTALL_PATH_ROOT_ID: &str = "game";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameMetadata {
+    pub api_version: u32,
+    pub name: String,
+    pub executable: String,
+    pub path_roots: Vec<GamePathRoot>,
+    pub mod_discovery: ModDiscovery,
+    pub load_order_writes: Vec<LoadOrderWriteTarget>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct GamePathRoot {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModDiscovery {
+    pub root_id: String,
+    pub relative_path: String,
+    pub mode: ModDiscoveryMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ModDiscoveryMode {
+    DirectoryMods {
+        required_prefix: Option<String>,
+        metadata_file: Option<String>,
+    },
+    PluginFiles {
+        extensions: Vec<String>,
+        excluded_files: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadOrderWriteTarget {
+    pub root_id: String,
+    pub relative_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildLoadOrderInput {
+    pub mods: Vec<ModEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildLoadOrderOutput {
+    pub writes: Vec<GameFileWrite>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameFileWrite {
+    pub root_id: String,
+    pub relative_path: String,
+    pub content: String,
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,7 +1,9 @@
 pub mod mod_manager;
+pub mod path_safety;
 pub mod plugin_manager;
 pub mod theme_manager;
 
 pub use mod_manager::ModManager;
+pub use path_safety::{join_validated_plugin_path, validate_plugin_relative_path};
 pub use plugin_manager::PluginManager;
 pub use theme_manager::ThemeManager;

--- a/src-tauri/src/services/mod_manager.rs
+++ b/src-tauri/src/services/mod_manager.rs
@@ -1,7 +1,10 @@
-use crate::models::{ModEntry, ModInfo, ModState};
-use anyhow::Result;
+use crate::models::{ModDiscovery, ModDiscoveryMode, ModEntry, ModInfo, ModState};
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use super::join_validated_plugin_path;
 
 pub struct ModManager {
     mods: Vec<ModInfo>,
@@ -21,21 +24,34 @@ impl ModManager {
     pub fn load_mods_for_plugin(
         &mut self,
         plugin_id: &str,
-        game_path: &str,
-        mod_directory: &str,
+        path_roots: &HashMap<String, String>,
+        discovery: &ModDiscovery,
     ) -> Result<()> {
         self.current_plugin = Some(plugin_id.to_string());
 
-        let mods_path = Path::new(game_path).join(mod_directory);
+        let root_path = path_roots.get(&discovery.root_id).ok_or_else(|| {
+            anyhow!(
+                "No path configured for root '{}' in plugin '{}'",
+                discovery.root_id,
+                plugin_id
+            )
+        })?;
+        let mods_path = join_validated_plugin_path(Path::new(root_path), &discovery.relative_path)
+            .map_err(anyhow::Error::msg)?;
         let mut discovered = if mods_path.exists() {
-            let has_dir_mods = fs::read_dir(&mods_path)?.filter_map(|e| e.ok()).any(|e| {
-                e.file_type().is_ok_and(|ft| ft.is_dir()) && e.path().join("mod.json").exists()
-            });
-
-            if has_dir_mods {
-                self.discover_directory_mods(&mods_path)?
-            } else {
-                self.discover_file_mods(&mods_path)?
+            match &discovery.mode {
+                ModDiscoveryMode::DirectoryMods {
+                    required_prefix,
+                    metadata_file,
+                } => self.discover_directory_mods(
+                    &mods_path,
+                    required_prefix.as_deref(),
+                    metadata_file.as_deref(),
+                )?,
+                ModDiscoveryMode::PluginFiles {
+                    extensions,
+                    excluded_files,
+                } => self.discover_plugin_files(&mods_path, extensions, excluded_files)?,
             }
         } else {
             Vec::new()
@@ -58,25 +74,41 @@ impl ModManager {
         Ok(())
     }
 
-    fn discover_directory_mods(&self, mods_path: &Path) -> Result<Vec<ModInfo>> {
+    fn discover_directory_mods(
+        &self,
+        mods_path: &Path,
+        required_prefix: Option<&str>,
+        metadata_file: Option<&str>,
+    ) -> Result<Vec<ModInfo>> {
         let mut discovered = Vec::new();
         for entry in fs::read_dir(mods_path)? {
             let entry = entry?;
             if !entry.file_type()?.is_dir() {
                 continue;
             }
-            let mod_json = entry.path().join("mod.json");
-            if !mod_json.exists() {
+
+            let mod_id = entry.file_name().to_string_lossy().to_string();
+            if required_prefix.is_some_and(|prefix| !mod_id.starts_with(prefix)) {
                 continue;
             }
-            let content = fs::read_to_string(&mod_json)?;
-            let meta: serde_json::Value = serde_json::from_str(&content)?;
-            let mod_id = entry.file_name().to_string_lossy().to_string();
+
+            let (name, version, description) = match metadata_file {
+                Some(file_name) => {
+                    let metadata_path = entry.path().join(file_name);
+                    if metadata_path.exists() {
+                        Self::read_directory_mod_metadata(&mod_id, &metadata_path)?
+                    } else {
+                        Self::directory_mod_defaults(&mod_id)
+                    }
+                }
+                None => Self::directory_mod_defaults(&mod_id),
+            };
+
             discovered.push(ModInfo {
-                id: mod_id.clone(),
-                name: meta["name"].as_str().unwrap_or(&mod_id).to_string(),
-                version: meta["version"].as_str().unwrap_or("1.0").to_string(),
-                description: meta["description"].as_str().unwrap_or("").to_string(),
+                id: mod_id,
+                name,
+                version,
+                description,
                 enabled: true,
                 priority: discovered.len() as u32,
             });
@@ -84,35 +116,81 @@ impl ModManager {
         Ok(discovered)
     }
 
-    fn discover_file_mods(&self, mods_path: &Path) -> Result<Vec<ModInfo>> {
+    fn directory_mod_defaults(mod_id: &str) -> (String, String, String) {
+        (
+            mod_id.to_string(),
+            "1.0".to_string(),
+            "Directory mod".to_string(),
+        )
+    }
+
+    fn read_directory_mod_metadata(
+        mod_id: &str,
+        metadata_path: &Path,
+    ) -> Result<(String, String, String)> {
+        let content = fs::read_to_string(metadata_path).map_err(|err| {
+            anyhow!(
+                "Failed to read mod metadata '{}': {err}",
+                metadata_path.display()
+            )
+        })?;
+        let metadata: serde_json::Value = serde_json::from_str(&content).map_err(|err| {
+            anyhow!(
+                "Failed to parse mod metadata '{}': {err}",
+                metadata_path.display()
+            )
+        })?;
+
+        Ok((
+            metadata["name"].as_str().unwrap_or(mod_id).to_string(),
+            metadata["version"].as_str().unwrap_or("1.0").to_string(),
+            metadata["description"].as_str().unwrap_or("").to_string(),
+        ))
+    }
+
+    fn discover_plugin_files(
+        &self,
+        mods_path: &Path,
+        extensions: &[String],
+        excluded_files: &[String],
+    ) -> Result<Vec<ModInfo>> {
+        let allowed_extensions: Vec<String> = extensions
+            .iter()
+            .map(|extension| extension.trim_start_matches('.').to_ascii_lowercase())
+            .filter(|extension| !extension.is_empty())
+            .collect();
+
         let mut discovered = Vec::new();
         for entry in fs::read_dir(mods_path)? {
             let entry = entry?;
             if !entry.file_type()?.is_file() {
                 continue;
             }
+
             let path = entry.path();
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-            if ext == "txt" || ext == "json" || ext == "ini" {
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            if excluded_files.iter().any(|excluded| excluded == &file_name) {
                 continue;
             }
-            let mod_id = path
+
+            let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+            if !allowed_extensions
+                .iter()
+                .any(|allowed| allowed == &extension.to_ascii_lowercase())
+            {
+                continue;
+            }
+
+            let name = path
                 .file_stem()
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_string();
-            let display_name = mod_id.chars().fold(String::new(), |mut acc, c| {
-                if c.is_uppercase() && !acc.is_empty() {
-                    acc.push(' ');
-                }
-                acc.push(c);
-                acc
-            });
             discovered.push(ModInfo {
-                id: mod_id,
-                name: display_name,
+                id: file_name,
+                name,
                 version: "1.0".to_string(),
-                description: format!(".{} mod", ext),
+                description: format!(".{extension} plugin"),
                 enabled: true,
                 priority: discovered.len() as u32,
             });
@@ -167,5 +245,131 @@ impl ModManager {
         let content = serde_json::to_string_pretty(&state)?;
         fs::write(profile_dir.join("modstate.json"), content)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static NEXT_TEST_DIR_ID: AtomicUsize = AtomicUsize::new(0);
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before UNIX_EPOCH")
+                .as_nanos();
+            let id = NEXT_TEST_DIR_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir()
+                .join(format!("umm-{name}-{}-{nanos}-{id}", std::process::id()));
+            fs::create_dir_all(&path).expect("create temp test directory");
+            Self { path }
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn touch(path: &Path) {
+        fs::create_dir_all(path.parent().expect("test file should have a parent"))
+            .expect("create test file parent");
+        fs::write(path, []).expect("write test file");
+    }
+
+    fn game_path_roots(game_root: &Path) -> HashMap<String, String> {
+        HashMap::from([("game".to_string(), game_root.to_string_lossy().to_string())])
+    }
+
+    #[test]
+    fn plugin_file_discovery_excludes_official_masters_and_keeps_extensions() {
+        let temp_dir = TestDir::new("plugin-file-discovery");
+        let game_root = temp_dir.path.join("game");
+        touch(&game_root.join("Data/Skyrim.esm"));
+        touch(&game_root.join("Data/Update.esm"));
+        touch(&game_root.join("Data/SkyUI_SE.esp"));
+        touch(&game_root.join("Data/ELFX.ESP"));
+        touch(&game_root.join("Data/readme.txt"));
+
+        let discovery = ModDiscovery {
+            root_id: "game".to_string(),
+            relative_path: "Data".to_string(),
+            mode: ModDiscoveryMode::PluginFiles {
+                extensions: vec!["esm".to_string(), ".esp".to_string(), "esl".to_string()],
+                excluded_files: vec![
+                    "Skyrim.esm".to_string(),
+                    "Update.esm".to_string(),
+                    "Dawnguard.esm".to_string(),
+                    "HearthFires.esm".to_string(),
+                    "Dragonborn.esm".to_string(),
+                ],
+            },
+        };
+        let mut manager = ModManager::new(&temp_dir.path);
+        let path_roots = game_path_roots(&game_root);
+        manager
+            .load_mods_for_plugin("skyrim-se", &path_roots, &discovery)
+            .expect("discover plugin files");
+
+        let mut ids = manager
+            .list_mods()
+            .into_iter()
+            .map(|game_mod| game_mod.id)
+            .collect::<Vec<_>>();
+        ids.sort();
+
+        assert_eq!(ids, vec!["ELFX.ESP", "SkyUI_SE.esp"]);
+    }
+
+    #[test]
+    fn directory_mod_discovery_requires_prefix_and_uses_directory_id() {
+        let temp_dir = TestDir::new("directory-mod-discovery");
+        let game_root = temp_dir.path.join("game");
+        fs::create_dir_all(game_root.join("mods/modHDCharacters/content"))
+            .expect("create Witcher mod directory");
+        fs::create_dir_all(game_root.join("mods/modArmorEnhanced/content"))
+            .expect("create Witcher mod directory");
+        fs::create_dir_all(game_root.join("mods/BetterWeather/content"))
+            .expect("create non-matching directory");
+        touch(&game_root.join("mods/modHDCharacters/content/texture.cache"));
+        touch(&game_root.join("mods/modArmorEnhanced/content/blob0.bundle"));
+
+        let discovery = ModDiscovery {
+            root_id: "game".to_string(),
+            relative_path: "mods".to_string(),
+            mode: ModDiscoveryMode::DirectoryMods {
+                required_prefix: Some("mod".to_string()),
+                metadata_file: None,
+            },
+        };
+        let mut manager = ModManager::new(&temp_dir.path);
+        let path_roots = game_path_roots(&game_root);
+        manager
+            .load_mods_for_plugin("witcher3", &path_roots, &discovery)
+            .expect("discover directory mods");
+
+        let mut mods = manager.list_mods();
+        mods.sort_by(|left, right| left.id.cmp(&right.id));
+
+        assert_eq!(
+            mods.iter()
+                .map(|game_mod| game_mod.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["modArmorEnhanced", "modHDCharacters"]
+        );
+        assert!(mods.iter().all(|game_mod| game_mod.name == game_mod.id));
+        assert!(mods
+            .iter()
+            .all(|game_mod| game_mod.description == "Directory mod"));
     }
 }

--- a/src-tauri/src/services/path_safety.rs
+++ b/src-tauri/src/services/path_safety.rs
@@ -1,0 +1,104 @@
+use std::path::{Component, Path, PathBuf};
+
+pub fn validate_plugin_relative_path(relative_path: &str) -> Result<(), String> {
+    if relative_path.trim().is_empty() {
+        return Err("Plugin returned an empty relative_path".to_string());
+    }
+
+    if relative_path.contains('\\') || relative_path.contains(':') {
+        return Err(format!(
+            "Plugin returned unsafe relative_path: {relative_path}"
+        ));
+    }
+
+    let path = Path::new(relative_path);
+    if path.is_absolute() {
+        return Err(format!(
+            "Plugin returned absolute relative_path: {relative_path}"
+        ));
+    }
+
+    let mut has_file_component = false;
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => has_file_component = true,
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
+                return Err(format!(
+                    "Plugin returned unsafe relative_path: {relative_path}"
+                ));
+            }
+        }
+    }
+
+    if !has_file_component {
+        return Err("Plugin returned an empty relative_path".to_string());
+    }
+
+    Ok(())
+}
+
+pub fn join_validated_plugin_path(root: &Path, relative_path: &str) -> Result<PathBuf, String> {
+    validate_plugin_relative_path(relative_path)?;
+    Ok(root.join(relative_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{join_validated_plugin_path, validate_plugin_relative_path};
+    use std::path::Path;
+
+    #[test]
+    fn plugin_relative_path_allows_normal_relative_paths() {
+        assert!(validate_plugin_relative_path("loadorder.txt").is_ok());
+        assert!(validate_plugin_relative_path("profiles/loadorder.txt").is_ok());
+        assert!(
+            validate_plugin_relative_path("local-app-data/Skyrim Special Edition/plugins.txt")
+                .is_ok()
+        );
+        assert!(validate_plugin_relative_path("documents/The Witcher 3/mods.settings").is_ok());
+    }
+
+    #[test]
+    fn plugin_relative_path_rejects_traversal_and_absolute_paths() {
+        for path in [
+            "",
+            ".",
+            "./loadorder.txt",
+            "../outside.txt",
+            "profiles/../../outside.txt",
+            "/tmp/outside.txt",
+        ] {
+            assert!(
+                validate_plugin_relative_path(path).is_err(),
+                "path should be rejected: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_relative_path_rejects_windows_prefixes_and_separators() {
+        for path in [
+            "C:/Users/player/outside.txt",
+            "C:\\Users\\player\\outside.txt",
+            "\\\\server\\share\\outside.txt",
+            "profiles\\loadorder.txt",
+        ] {
+            assert!(
+                validate_plugin_relative_path(path).is_err(),
+                "path should be rejected: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn validated_plugin_path_joins_without_canonicalizing() {
+        let root = Path::new("/missing/game-root");
+        let path = join_validated_plugin_path(root, "documents/The Witcher 3/mods.settings")
+            .expect("valid path should join");
+
+        assert_eq!(path, root.join("documents/The Witcher 3/mods.settings"));
+    }
+}

--- a/src-tauri/src/services/plugin_manager.rs
+++ b/src-tauri/src/services/plugin_manager.rs
@@ -1,7 +1,13 @@
-use crate::models::{PluginInfo, PluginMetadata};
+use crate::models::{
+    BuildLoadOrderInput, BuildLoadOrderOutput, GameMetadata, PluginInfo, PluginMetadata,
+    SUPPORTED_PLUGIN_API_VERSION,
+};
 use anyhow::Result;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use super::validate_plugin_relative_path;
 
 struct DiscoveredPlugin {
     info: PluginInfo,
@@ -77,7 +83,30 @@ impl PluginManager {
         self.active_plugin_id.as_deref()
     }
 
-    pub fn call_plugin_fn(&self, plugin_id: &str, fn_name: &str, input: &str) -> Result<String> {
+    pub fn game_metadata(&self, plugin_id: &str) -> Result<GameMetadata> {
+        let metadata_json = self.call_plugin_fn(plugin_id, "get_game_metadata", "")?;
+        let metadata: GameMetadata = serde_json::from_str(&metadata_json)?;
+        validate_game_metadata(plugin_id, &metadata)?;
+        Ok(metadata)
+    }
+
+    pub fn build_load_order(
+        &self,
+        plugin_id: &str,
+        input: &BuildLoadOrderInput,
+    ) -> Result<BuildLoadOrderOutput> {
+        let input_json = serde_json::to_string(input)?;
+        let output_json = self.call_plugin_fn(plugin_id, "build_load_order", &input_json)?;
+        let output: BuildLoadOrderOutput = serde_json::from_str(&output_json)?;
+
+        if output.writes.is_empty() {
+            anyhow::bail!("Plugin '{plugin_id}' returned no load-order writes");
+        }
+
+        Ok(output)
+    }
+
+    fn call_plugin_fn(&self, plugin_id: &str, fn_name: &str, input: &str) -> Result<String> {
         let plugin = self
             .plugins
             .iter()
@@ -115,9 +144,77 @@ impl PluginManager {
     }
 }
 
+fn validate_game_metadata(plugin_id: &str, metadata: &GameMetadata) -> Result<()> {
+    if metadata.api_version != SUPPORTED_PLUGIN_API_VERSION {
+        anyhow::bail!(
+            "Plugin '{plugin_id}' uses API version {}, but this app supports version {}",
+            metadata.api_version,
+            SUPPORTED_PLUGIN_API_VERSION
+        );
+    }
+
+    if metadata.path_roots.is_empty() {
+        anyhow::bail!("Plugin '{plugin_id}' declares no path roots");
+    }
+
+    let mut root_ids = HashSet::new();
+    for root in &metadata.path_roots {
+        if root.id.trim().is_empty() {
+            anyhow::bail!("Plugin '{plugin_id}' declares an empty path root id");
+        }
+        if root.name.trim().is_empty() {
+            anyhow::bail!("Plugin '{plugin_id}' declares an empty path root name");
+        }
+        if !root_ids.insert(root.id.as_str()) {
+            anyhow::bail!(
+                "Plugin '{plugin_id}' declares duplicate path root '{}'",
+                root.id
+            );
+        }
+    }
+
+    if !root_ids.contains(metadata.mod_discovery.root_id.as_str()) {
+        anyhow::bail!(
+            "Plugin '{plugin_id}' uses undeclared discovery path root '{}'",
+            metadata.mod_discovery.root_id
+        );
+    }
+    validate_plugin_relative_path(&metadata.mod_discovery.relative_path)
+        .map_err(anyhow::Error::msg)?;
+
+    if metadata.load_order_writes.is_empty() {
+        anyhow::bail!("Plugin '{plugin_id}' declares no load-order writes");
+    }
+
+    let mut declared_paths = HashSet::new();
+    for target in &metadata.load_order_writes {
+        if !root_ids.contains(target.root_id.as_str()) {
+            anyhow::bail!(
+                "Plugin '{plugin_id}' declares load-order path '{}' under undeclared root '{}'",
+                target.relative_path,
+                target.root_id
+            );
+        }
+        validate_plugin_relative_path(&target.relative_path).map_err(anyhow::Error::msg)?;
+        if !declared_paths.insert((target.root_id.as_str(), target.relative_path.as_str())) {
+            anyhow::bail!(
+                "Plugin '{plugin_id}' declares duplicate load-order path '{}:{}'",
+                target.root_id,
+                target.relative_path
+            );
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::{
+        BuildLoadOrderInput, GamePathRoot, LoadOrderWriteTarget, ModDiscovery, ModDiscoveryMode,
+        ModEntry,
+    };
     use serde_json::Value;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -155,18 +252,23 @@ mod tests {
             .to_path_buf()
     }
 
-    fn security_test_manager() -> (TestDir, PluginManager) {
-        let temp_dir = TestDir::new("plugin-security");
+    fn bundled_plugin_manager(
+        plugin_id: &str,
+        wasm_name: &str,
+        target: &str,
+    ) -> (TestDir, PluginManager) {
+        let temp_dir = TestDir::new(plugin_id);
         let project_root = project_root();
-        let plugin_src = project_root.join("plugins/security-test");
-        let wasm_src = plugin_src.join("target/wasm32-wasip1/release/security_test_plugin.wasm");
+        let plugin_src = project_root.join(format!("plugins/{plugin_id}"));
+        let wasm_src = plugin_src.join(format!("target/{target}/release/{wasm_name}.wasm"));
 
         assert!(
             wasm_src.exists(),
-            "security-test WASM missing; run `cargo build --release --target wasm32-wasip1` in plugins/security-test first"
+            "bundled plugin WASM missing at '{}'; build the plugin before running this test",
+            wasm_src.display()
         );
 
-        let plugin_dest = temp_dir.path.join("plugins/security-test");
+        let plugin_dest = temp_dir.path.join("plugins").join(plugin_id);
         fs::create_dir_all(&plugin_dest).expect("create plugin test directory");
         fs::copy(
             plugin_src.join("metadata.json"),
@@ -177,10 +279,12 @@ mod tests {
         fs::write(plugin_dest.join("icon.png"), []).expect("create plugin icon");
 
         let mut manager = PluginManager::new(&temp_dir.path);
-        manager
-            .discover_plugins()
-            .expect("discover security-test plugin");
+        manager.discover_plugins().expect("discover bundled plugin");
         (temp_dir, manager)
+    }
+
+    fn security_test_manager() -> (TestDir, PluginManager) {
+        bundled_plugin_manager("security-test", "security_test_plugin", "wasm32-wasip1")
     }
 
     fn assert_probe_blocked(json: &str, expected_operations: &[&str]) {
@@ -201,6 +305,201 @@ mod tests {
                 "probe operation should be blocked: {expected_operation}, output: {json}"
             );
         }
+    }
+
+    fn valid_metadata() -> GameMetadata {
+        GameMetadata {
+            api_version: SUPPORTED_PLUGIN_API_VERSION,
+            name: "Example".to_string(),
+            executable: "game.exe".to_string(),
+            path_roots: vec![GamePathRoot {
+                id: "game".to_string(),
+                name: "Game folder".to_string(),
+                description: "Game install folder".to_string(),
+            }],
+            mod_discovery: ModDiscovery {
+                root_id: "game".to_string(),
+                relative_path: "mods".to_string(),
+                mode: ModDiscoveryMode::DirectoryMods {
+                    required_prefix: None,
+                    metadata_file: None,
+                },
+            },
+            load_order_writes: vec![LoadOrderWriteTarget {
+                root_id: "game".to_string(),
+                relative_path: "loadorder.txt".to_string(),
+            }],
+        }
+    }
+
+    fn mod_entry(id: &str, enabled: bool, priority: u32) -> ModEntry {
+        ModEntry {
+            id: id.to_string(),
+            enabled,
+            priority,
+        }
+    }
+
+    #[test]
+    fn game_metadata_validation_rejects_unsupported_api_version() {
+        let mut metadata = valid_metadata();
+        metadata.api_version = 1;
+
+        let message = validate_game_metadata("example", &metadata)
+            .expect_err("unsupported API version should be rejected")
+            .to_string();
+
+        assert_eq!(
+            message,
+            "Plugin 'example' uses API version 1, but this app supports version 2"
+        );
+    }
+
+    #[test]
+    fn game_metadata_validation_rejects_empty_load_order_writes() {
+        let mut metadata = valid_metadata();
+        metadata.load_order_writes.clear();
+
+        let message = validate_game_metadata("example", &metadata)
+            .expect_err("empty write targets should be rejected")
+            .to_string();
+
+        assert_eq!(message, "Plugin 'example' declares no load-order writes");
+    }
+
+    #[test]
+    fn game_metadata_validation_rejects_duplicate_path_roots() {
+        let mut metadata = valid_metadata();
+        metadata.path_roots.push(GamePathRoot {
+            id: "game".to_string(),
+            name: "Duplicate game folder".to_string(),
+            description: "Duplicate root".to_string(),
+        });
+
+        let message = validate_game_metadata("example", &metadata)
+            .expect_err("duplicate path root should be rejected")
+            .to_string();
+
+        assert_eq!(
+            message,
+            "Plugin 'example' declares duplicate path root 'game'"
+        );
+    }
+
+    #[test]
+    fn game_metadata_validation_rejects_undeclared_write_roots() {
+        let mut metadata = valid_metadata();
+        metadata.load_order_writes[0].root_id = "documents".to_string();
+
+        let message = validate_game_metadata("example", &metadata)
+            .expect_err("undeclared write root should be rejected")
+            .to_string();
+
+        assert_eq!(
+            message,
+            "Plugin 'example' declares load-order path 'loadorder.txt' under undeclared root 'documents'"
+        );
+    }
+
+    #[test]
+    fn game_metadata_validation_rejects_duplicate_write_targets() {
+        let mut metadata = valid_metadata();
+        metadata.load_order_writes.push(LoadOrderWriteTarget {
+            root_id: "game".to_string(),
+            relative_path: "loadorder.txt".to_string(),
+        });
+
+        let message = validate_game_metadata("example", &metadata)
+            .expect_err("duplicate write target should be rejected")
+            .to_string();
+
+        assert_eq!(
+            message,
+            "Plugin 'example' declares duplicate load-order path 'game:loadorder.txt'"
+        );
+    }
+
+    #[test]
+    fn game_metadata_validation_rejects_unsafe_write_targets() {
+        let mut metadata = valid_metadata();
+        metadata.load_order_writes = vec![LoadOrderWriteTarget {
+            root_id: "game".to_string(),
+            relative_path: "../outside.txt".to_string(),
+        }];
+
+        let message = validate_game_metadata("example", &metadata)
+            .expect_err("unsafe write target should be rejected")
+            .to_string();
+
+        assert!(
+            message.contains("Plugin returned unsafe relative_path: ../outside.txt"),
+            "unexpected unsafe path error: {message}"
+        );
+    }
+
+    #[test]
+    fn skyrim_plugin_wasm_round_trip_builds_declared_load_order_writes() {
+        let (_temp_dir, manager) =
+            bundled_plugin_manager("skyrim-se", "skyrim_se_plugin", "wasm32-unknown-unknown");
+        let metadata = manager
+            .game_metadata("skyrim-se")
+            .expect("load Skyrim metadata");
+        let input = BuildLoadOrderInput {
+            mods: vec![
+                mod_entry("ELFX.esp", false, 30),
+                mod_entry("WeatherOverhaul.esp", true, 10),
+            ],
+        };
+
+        let output = manager
+            .build_load_order("skyrim-se", &input)
+            .expect("build Skyrim load order");
+        let declared_paths = metadata
+            .load_order_writes
+            .iter()
+            .map(|target| (target.root_id.as_str(), target.relative_path.as_str()))
+            .collect::<Vec<_>>();
+
+        assert!(declared_paths.contains(&("local_app_data", "plugins.txt")));
+        assert!(declared_paths.contains(&("local_app_data", "loadorder.txt")));
+        assert_eq!(output.writes.len(), 2);
+
+        let plugins_txt = output
+            .writes
+            .iter()
+            .find(|write| write.root_id == "local_app_data" && write.relative_path == "plugins.txt")
+            .expect("plugins.txt write");
+        assert_eq!(
+            plugins_txt.content,
+            "*Skyrim.esm\n*Update.esm\n*Dawnguard.esm\n*HearthFires.esm\n*Dragonborn.esm\n*WeatherOverhaul.esp\nELFX.esp\n"
+        );
+    }
+
+    #[test]
+    fn witcher_plugin_wasm_round_trip_builds_declared_mods_settings() {
+        let (_temp_dir, manager) =
+            bundled_plugin_manager("witcher3", "witcher3_plugin", "wasm32-unknown-unknown");
+        let metadata = manager
+            .game_metadata("witcher3")
+            .expect("load Witcher metadata");
+        let input = BuildLoadOrderInput {
+            mods: vec![
+                mod_entry("modBetterWeather", false, 20),
+                mod_entry("modArmorEnhanced", true, 10),
+            ],
+        };
+
+        let output = manager
+            .build_load_order("witcher3", &input)
+            .expect("build Witcher load order");
+
+        assert_eq!(metadata.load_order_writes[0].root_id, "documents");
+        assert_eq!(metadata.load_order_writes[0].relative_path, "mods.settings");
+        assert_eq!(output.writes.len(), 1);
+        assert_eq!(
+            output.writes[0].content,
+            "[modArmorEnhanced]\nEnabled=1\nPriority=1\n\n[modBetterWeather]\nEnabled=0\nPriority=2\n"
+        );
     }
 
     #[test]

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -53,17 +53,25 @@ async selectPlugin(pluginId: string) : Promise<Result<ModInfo[], string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getGamePaths() : Promise<Result<Partial<{ [key in string]: string }>, string>> {
+async getPluginPathRoots(pluginId: string) : Promise<Result<GamePathRoot[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_game_paths") };
+    return { status: "ok", data: await TAURI_INVOKE("get_plugin_path_roots", { pluginId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
 },
-async setGamePath(pluginId: string, path: string) : Promise<Result<null, string>> {
+async getPluginPaths() : Promise<Result<Partial<{ [key in string]: Partial<{ [key in string]: string }> }>, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("set_game_path", { pluginId, path }) };
+    return { status: "ok", data: await TAURI_INVOKE("get_plugin_paths") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async setPluginPath(pluginId: string, rootId: string, path: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_plugin_path", { pluginId, rootId, path }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -113,6 +121,7 @@ async setActiveTheme(themeName: string) : Promise<Result<string, string>> {
 
 /** user-defined types **/
 
+export type GamePathRoot = { id: string; name: string; description: string }
 export type ModInfo = { id: string; name: string; version: string; description: string; enabled: boolean; priority: number }
 export type PluginInfo = { id: string; name: string; icon_path: string }
 export type ThemeInfo = { name: string; is_active: boolean }

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -3,9 +3,9 @@
     import ModList from "./ModList.svelte";
     import { appState } from "$lib/stores/app.svelte";
 
-    const hasGamePath = $derived(
+    const hasRequiredPaths = $derived(
         appState.activePluginId
-            ? !!appState.gamePaths[appState.activePluginId]
+            ? appState.hasConfiguredPluginPaths(appState.activePluginId)
             : false,
     );
 
@@ -20,7 +20,7 @@
         <header class="umm-content-header">
             <div>
                 <h1 class="umm-content-title">{contentTitle}</h1>
-                {#if appState.activePluginId && hasGamePath}
+                {#if appState.activePluginId && hasRequiredPaths}
                     <p class="umm-content-subtitle">
                         {appState.mods.length} mod{appState.mods.length !== 1 ? "s" : ""} loaded
                     </p>
@@ -33,9 +33,9 @@
                 <p class="umm-mod-list-empty">Loading...</p>
             {:else if !appState.activePluginId}
                 <p class="umm-mod-list-empty">Select a game plugin to get started</p>
-            {:else if !hasGamePath}
+            {:else if !hasRequiredPaths}
                 <p class="umm-mod-list-empty">
-                    Open settings to set the game directory and load mods
+                    Open settings to set the required game paths and load mods
                 </p>
             {:else if appState.modLoadError}
                 <p class="umm-error-message" role="alert">{appState.modLoadError}</p>

--- a/src/lib/components/GamePathSetting.svelte
+++ b/src/lib/components/GamePathSetting.svelte
@@ -2,36 +2,39 @@
     import { FolderOpen } from "lucide-svelte";
     import { appState } from "$lib/stores/app.svelte";
 
-    const currentPath = $derived(
-        appState.activePluginId
-            ? appState.gamePaths[appState.activePluginId]
-            : undefined,
+    const activePluginId = $derived(appState.activePluginId);
+    const pathRoots = $derived(
+        activePluginId ? (appState.pluginPathRoots[activePluginId] ?? []) : [],
     );
 
-    const displayPath = $derived(
-        currentPath
-            ? currentPath.length > 30
-                ? "..." + currentPath.slice(-30)
-                : currentPath
-            : "No path set",
-    );
+    function displayPath(path: string | undefined): string {
+        if (!path) return "No path set";
+        return path.length > 30 ? "..." + path.slice(-30) : path;
+    }
 </script>
 
-{#if appState.activePluginId}
+{#if activePluginId && pathRoots.length > 0}
     <div class="umm-game-path">
-        <button
-            class="umm-game-path-btn"
-            onclick={() =>
-                appState.activePluginId &&
-                appState.browseGamePath(appState.activePluginId)}
-            title={currentPath ?? "Click to set game directory"}
-        >
-            <span class="umm-game-path-icon">
-                <FolderOpen size={14} />
-            </span>
-            <span class="umm-game-path-text" class:umm-game-path-text--empty={!currentPath}>
-                {displayPath}
-            </span>
-        </button>
+        {#each pathRoots as pathRoot (pathRoot.id)}
+            {@const currentPath = appState.pluginPaths[activePluginId]?.[pathRoot.id]}
+            <div class="umm-game-path-item">
+                <span class="umm-game-path-label">{pathRoot.name}</span>
+                <button
+                    class="umm-game-path-btn"
+                    onclick={() => appState.browsePluginPath(activePluginId, pathRoot.id)}
+                    title={currentPath ?? pathRoot.description}
+                >
+                    <span class="umm-game-path-icon">
+                        <FolderOpen size={14} />
+                    </span>
+                    <span class="umm-game-path-text" class:umm-game-path-text--empty={!currentPath}>
+                        {displayPath(currentPath)}
+                    </span>
+                </button>
+                {#if pathRoot.description}
+                    <span class="umm-game-path-description">{pathRoot.description}</span>
+                {/if}
+            </div>
+        {/each}
     </div>
 {/if}

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -1,4 +1,4 @@
-import { commands, type ModInfo, type PluginInfo, type ThemeInfo, type Result } from "$lib/bindings";
+import { commands, type GamePathRoot, type ModInfo, type PluginInfo, type ThemeInfo, type Result } from "$lib/bindings";
 import { open } from "@tauri-apps/plugin-dialog";
 
 function unwrap<T>(result: Result<T, string>): T {
@@ -6,12 +6,18 @@ function unwrap<T>(result: Result<T, string>): T {
     throw new Error(result.error);
 }
 
-function compactStringRecord(record: Partial<Record<string, string>>): Record<string, string> {
-    const entries = Object.entries(record).filter(
-        (entry): entry is [string, string] => typeof entry[1] === "string",
-    );
+function compactPluginPaths(
+    record: Partial<Record<string, Partial<Record<string, string>>>>,
+): Record<string, Record<string, string>> {
+    const pluginEntries = Object.entries(record).map(([pluginId, rootPaths]) => {
+        const pathEntries = Object.entries(rootPaths ?? {}).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+        );
 
-    return Object.fromEntries(entries);
+        return [pluginId, Object.fromEntries(pathEntries)] as const;
+    });
+
+    return Object.fromEntries(pluginEntries);
 }
 
 function reorderModList(mods: ModInfo[], modIds: string[]): ModInfo[] {
@@ -30,7 +36,8 @@ class AppState {
     themes = $state<ThemeInfo[]>([]);
     activeThemeName = $state("");
     themeCss = $state("");
-    gamePaths = $state<Record<string, string>>({});
+    pluginPaths = $state<Record<string, Record<string, string>>>({});
+    pluginPathRoots = $state<Record<string, GamePathRoot[]>>({});
     loading = $state(true);
     modLoadError = $state<string | null>(null);
 
@@ -38,7 +45,7 @@ class AppState {
         try {
             this.plugins = unwrap(await commands.listPlugins());
             this.themes = unwrap(await commands.listThemes());
-            this.gamePaths = compactStringRecord(unwrap(await commands.getGamePaths()));
+            this.pluginPaths = compactPluginPaths(unwrap(await commands.getPluginPaths()));
             this.activeThemeName = unwrap(await commands.getActiveTheme());
             if (this.activeThemeName) {
                 this.themeCss = unwrap(await commands.getThemeCss(this.activeThemeName));
@@ -47,7 +54,15 @@ class AppState {
             const active = unwrap(await commands.getActivePlugin());
             if (active) {
                 this.activePluginId = active;
-                this.mods = unwrap(await commands.listMods());
+                try {
+                    await this.loadPluginPathRoots(active);
+                    if (this.hasConfiguredPluginPaths(active)) {
+                        this.mods = unwrap(await commands.listMods());
+                    }
+                } catch (error) {
+                    this.mods = [];
+                    this.modLoadError = error instanceof Error ? error.message : String(error);
+                }
             }
         } finally {
             this.loading = false;
@@ -58,17 +73,20 @@ class AppState {
         this.activePluginId = pluginId;
         this.modLoadError = null;
 
-        if (!this.gamePaths[pluginId]) {
+        try {
+            await this.loadPluginPathRoots(pluginId);
+        } catch (error) {
+            this.mods = [];
+            this.modLoadError = error instanceof Error ? error.message : String(error);
+            return;
+        }
+
+        if (!this.hasConfiguredPluginPaths(pluginId)) {
             this.mods = [];
             return;
         }
 
-        try {
-            this.mods = unwrap(await commands.selectPlugin(pluginId));
-        } catch (error) {
-            this.mods = [];
-            this.modLoadError = error instanceof Error ? error.message : String(error);
-        }
+        await this.loadSelectedPluginMods(pluginId);
     }
 
     async toggleMod(modId: string, enabled: boolean) {
@@ -90,25 +108,58 @@ class AppState {
         }
     }
 
-    async browseGamePath(pluginId: string) {
+    async browsePluginPath(pluginId: string, rootId: string) {
+        const roots = await this.loadPluginPathRoots(pluginId);
+        const root = roots.find((pathRoot) => pathRoot.id === rootId);
         const selected = await open({
             directory: true,
             multiple: false,
-            title: "Select game directory",
+            title: `Select ${root?.name ?? "plugin path"}`,
         });
-        if (!selected) return;
+        if (!selected || Array.isArray(selected)) return;
 
         this.modLoadError = null;
-        unwrap(await commands.setGamePath(pluginId, selected));
-        this.gamePaths = { ...this.gamePaths, [pluginId]: selected };
+        unwrap(await commands.setPluginPath(pluginId, rootId, selected));
+        this.pluginPaths = {
+            ...this.pluginPaths,
+            [pluginId]: {
+                ...(this.pluginPaths[pluginId] ?? {}),
+                [rootId]: selected,
+            },
+        };
 
         if (this.activePluginId === pluginId) {
-            try {
-                this.mods = unwrap(await commands.selectPlugin(pluginId));
-            } catch (error) {
+            if (this.hasConfiguredPluginPaths(pluginId)) {
+                await this.loadSelectedPluginMods(pluginId);
+            } else {
                 this.mods = [];
-                this.modLoadError = error instanceof Error ? error.message : String(error);
             }
+        }
+    }
+
+    async loadPluginPathRoots(pluginId: string): Promise<GamePathRoot[]> {
+        const cached = this.pluginPathRoots[pluginId];
+        if (cached) return cached;
+
+        const roots = unwrap(await commands.getPluginPathRoots(pluginId));
+        this.pluginPathRoots = { ...this.pluginPathRoots, [pluginId]: roots };
+        return roots;
+    }
+
+    hasConfiguredPluginPaths(pluginId: string): boolean {
+        const roots = this.pluginPathRoots[pluginId] ?? [];
+        const paths = this.pluginPaths[pluginId] ?? {};
+
+        return roots.length > 0 && roots.every((root) => !!paths[root.id]);
+    }
+
+
+    async loadSelectedPluginMods(pluginId: string) {
+        try {
+            this.mods = unwrap(await commands.selectPlugin(pluginId));
+        } catch (error) {
+            this.mods = [];
+            this.modLoadError = error instanceof Error ? error.message : String(error);
         }
     }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -563,7 +563,24 @@ body {
 }
 
 .umm-game-path {
+  display: flex;
+  flex-direction: column;
+  gap: var(--umm-space-sm);
   margin-top: var(--umm-space-sm);
+}
+
+.umm-game-path-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--umm-space-2xs);
+}
+
+.umm-game-path-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--umm-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .umm-game-path-btn {
@@ -606,6 +623,12 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.umm-game-path-description {
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--umm-text-muted);
 }
 
 .umm-game-path-text--empty {


### PR DESCRIPTION
Replace the single mod_directory/load_order_file plugin contract with a declarative API (api_version 2): path_roots, mod_discovery, and load_order_writes. Plugins now build (not write) load orders, and the host validates and writes every declared target.

- Skyrim SE writes plugins.txt + loadorder.txt to the local-app-data root, with official masters prepended and enabled mods marked with '*'.
- Witcher 3 writes mods.settings to the documents root.
- Add GameMetadata validation (API version, unique roots, declared/safe write targets) and reject undeclared load-order writes at write time.
- Add ModDiscovery modes (DirectoryMods with prefix/metadata, PluginFiles with extension/exclusion filters).
- Migrate config game_paths -> plugin_paths keyed by root id on load.
- Extract path_safety service; frontend now manages multiple path roots per plugin.